### PR TITLE
0022.1: OpenAPI v1 — LOC Compression + YAMLlint fix

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4,8 +4,8 @@ info:
   version: "1.0.0"
   description: Authoritative contract for POST /api/plan. Non-auth, privacy-first. Spectral lint must pass with 0 errors; warnings allowed.
   contact: { name: PayPlan API, url: "https://github.com/mmtuentertainment/PayPlan" }
-tags: [{ name: plan, description: Payment planning operations }]
-servers: [{ url: "https://api.example.com", description: "Illustrative; clients typically call relative path" }]
+tags: [{name: plan, description: Payment planning operations}]
+servers: [{url: "https://api.example.com", description: "Illustrative; clients typically call relative path"}]
 paths:
   /api/plan:
     post:


### PR DESCRIPTION
## Summary

Flow-style YAML compression + yamllint compliance for api/openapi.yaml.

## Changes

1. **Original compression** (from old PR #16):
   - Global tags: 3 lines → 1 line (flow-style)
   - Servers array: 3 lines → 1 line (flow-style)  
   - POST description: 4 lines → 1 line (compact)
   - **Saved**: 7 lines (180 → 173 LOC)

2. **YAMLlint fix** (new):
   - Remove spaces in flow-style braces
   - `tags: [{ name: ...` → `tags: [{name: ...`
   - `servers: [{ url: ...` → `servers: [{url: ...`

## Verification

- Spectral: 0 errors ✅
- YAMLlint: All braces spacing fixed ✅
- Constitution: LOC 173/180, formatting-only, reversible ✅

## Related

Replaces closed PR #16 (webhook incident prevented merge after rebase)
